### PR TITLE
Deleting all products associated to a request when request is deleted

### DIFF
--- a/app/controllers/iise_budget_tracker_controller.rb
+++ b/app/controllers/iise_budget_tracker_controller.rb
@@ -55,6 +55,7 @@ class IiseBudgetTrackerController < ApplicationController
 	def destroy 
 	@budget_request = BudgetRequest.find(params[:id])
 	if @budget_request.present?
+		@budget_request.products.destroy_all
 		@budget_request.destroy
 	end
 		redirect_to iise_budget_tracker_index_path


### PR DESCRIPTION
Bug Fix
Description: products remained in the database after the request they are associated with was deleted.
Performance concerns and guidelines: wasting memory on product database.
